### PR TITLE
Desabilita verificação CSRF

### DIFF
--- a/nisia/settings.py
+++ b/nisia/settings.py
@@ -46,7 +46,6 @@ MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',


### PR DESCRIPTION
O Django por padrão vem com proteção CSRF em todos os formulários, o que impede o envio do formulário se ele vier de um dominio diferente do esperado. O problema é que isso é desnecessário no nosso caso já que estamos lidando apenas com captação de lead, então acaba sendo um recurso extra sendo consumido e bloqueando nossos testes sem necessidade.